### PR TITLE
Allow customer headers during JWT generation

### DIFF
--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -25,6 +25,7 @@ module Signet
   module OAuth2
     class Client
       OOB_MODES = ["urn:ietf:wg:oauth:2.0:oob:auto", "urn:ietf:wg:oauth:2.0:oob", "oob"].freeze
+      ID_TOKEN_TYPE = 'JWT'.freeze
 
       ##
       # Creates an OAuth 2.0 client.
@@ -602,7 +603,7 @@ module Signet
       # @param [Hash] new_additional_claims
       #   Additional claims
       def additional_claims= new_additional_claims
-        @additional_claims = new_additional_claims
+        @additional_claims = deep_hash_normalize(new_additional_claims)
       end
 
       ##
@@ -921,7 +922,7 @@ module Signet
         assertion["prn"] = person unless person.nil?
         assertion["sub"] = sub unless sub.nil?
         assertion.merge! additional_claims
-        JWT.encode assertion, signing_key, signing_algorithm
+        JWT.encode assertion, signing_key, signing_algorithm, header_fields=options.fetch(:header_fields, {})
       end
       # rubocop:disable Style/MethodDefParentheses
 

--- a/lib/signet/version.rb
+++ b/lib/signet/version.rb
@@ -19,7 +19,7 @@ unless defined? Signet::VERSION
       MAJOR = 0
       MINOR = 11
       TINY  = 0
-      PRE   = 'liveramp-001'
+      PRE   = 'liveramp-002'
 
       STRING = [MAJOR, MINOR, TINY, PRE].compact.join "."
 


### PR DESCRIPTION
This allows custom headers to be included in the options passed to
the to_jwt method, so that e.g. key id and type headers can be included.
This also adds a convenience constant for the JWT type commonly used in
the type header. Lastly, it calls #deep_normalize_hash on the
additional_claims hash to allow indifferent access.