### PR TITLE
Source gem dependencies from public-gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "https://private-gems.liveramp.net" do
+source "https://public-gems.liveramp.net" do
   gemspec
 
   gem "bundler", ">= 1.15"

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ task :ci_release => ['generate_rubygems_credentials', 'build', 'release:guard_cl
 
 task :generate_rubygems_credentials do
   require 'base64'
-  GEM_CREDENTIALS = File.join(ENV['HOME'], '/.gem/credentials')
+  GEM_CREDENTIALS = File.join(ENV['HOME'], '.gem/credentials')
   b64_authorization = Base64.encode64("#{ENV.fetch('ARTIFACTORY_USERNAME')}:#{ENV.fetch('ARTIFACTORY_PASSWORD')}")
   open(GEM_CREDENTIALS, 'w') do |f|
     f.puts "---\n:rubygems_api_key: Basic #{b64_authorization}\n"


### PR DESCRIPTION
`private-gems.liveramp.net` is intentionally not a mirror cache of ruby-gems.org, whereas public-gems is. This changes the Gemfile so that dependent gems are pulled from the mirror cache.
